### PR TITLE
Fix workspaces update being blocked

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -22,7 +22,8 @@ function init() {};
 
 function enable() {
     display = WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype.display;
-    WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype.display = function() {};
+    WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype.display =
+      WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype.destroy;
 }
 
 function disable() {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.8","3.10"], 
+    "shell-version": ["3.8","3.10", "3.30"],
     "uuid": "no-workspace-switcher-popup@devbury.com", 
     "name": "No Workspace Switcher Popup", 
     "description": "Don't display the workspace switcher popup when switching workspaces"


### PR DESCRIPTION
The extension is not working with Gnome 3.30. My guess is that a destroy method is not being called which  prevents workspaces updates.
See https://gitlab.gnome.org/GNOME/gnome-shell/blob/master/js/ui/windowManager.js#L2112-2116.