### PR TITLE
Add GNOME 40 to the list of supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.8","3.10"], 
+    "shell-version": ["3.8","3.10","40"],
     "uuid": "no-workspace-switcher-popup@devbury.com", 
     "name": "No Workspace Switcher Popup", 
     "description": "Don't display the workspace switcher popup when switching workspaces"


### PR DESCRIPTION
Other than the metadata, this extension still works perfectly in GNOME 40, but it won't install without this metadata change.